### PR TITLE
Add initialization steps to EC2 spot instance to start Minecraft server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "tweetnacl": "^1.0.3"
       },
       "bin": {
-        "mine-cloud": "bin/mine-cloud.js"
+        "mine-cloud": "dist/bin/mine-cloud.js"
       },
       "devDependencies": {
         "@types/jest": "^29.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "mine-cloud",
   "version": "0.1.0",
   "bin": {
-    "mine-cloud": "bin/mine-cloud.js"
+    "mine-cloud": "dist/bin/mine-cloud.js"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "scripts": {
     "build": "tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": [
       "es2020"
     ],
+    "outDir": "dist",
     "declaration": true,
     "strict": true,
     "noImplicitAny": true,
@@ -21,10 +22,11 @@
     "strictPropertyInitialization": false,
     "typeRoots": [
       "./node_modules/@types"
-    ]
+    ],
   },
   "exclude": [
     "node_modules",
-    "cdk.out"
+    "cdk.out",
+    "dist"
   ]
 }


### PR DESCRIPTION
* Changes build to output to dist/ instead of same directory

* Uses CDK Instance `init` property to install/start Minecraft server