### PR TITLE
Setup Discord BOT commands during EC2 initialization

### DIFF
--- a/lambda/discord_commands_register/index.ts
+++ b/lambda/discord_commands_register/index.ts
@@ -1,0 +1,52 @@
+import {
+    CdkCustomResourceEvent,
+    CdkCustomResourceResponse,
+    Context,
+  } from 'aws-lambda';
+import axios from 'axios';
+
+exports.handler = async (event: CdkCustomResourceEvent,
+    context: Context,) => {
+    
+    if (event.RequestType !== 'Delete') {
+        const apiEndpoint = `https://discord.com/api/v10/applications/${process.env.APP_ID}/commands`;
+        await registerCommand("mc_start", "Start the minecraft server", apiEndpoint);
+        await registerCommand("mc_stop", "Start the minecraft server", apiEndpoint);
+        await registerCommand("mc_backup", "Start the minecraft server", apiEndpoint);
+        await registerCommand("mc_restart", "Start the minecraft server", apiEndpoint);
+        console.log("Discord command register completed");
+    }
+   
+
+    const response: CdkCustomResourceResponse = {
+        StackId: event.StackId,
+        RequestId: event.RequestId,
+        LogicalResourceId: event.LogicalResourceId,
+        PhysicalResourceId: context.logGroupName,
+    };
+
+    response.Status = 'SUCCESS';
+    response.Data = { Result: 'None' };
+    return response;
+}
+
+async function registerCommand(commandName: string, description: string, endPoint: string) {
+    const header = {
+        "Authorization": `Bot ${process.env.BOT_TOKEN}`
+    }
+    const body = {
+        "name": commandName,
+        "type": 1,
+        "description": description,
+    }
+    const request = {
+        method: 'post',
+        url: endPoint,
+        headers: header,
+        data: body
+    };
+
+    console.log('register request: ', request);
+    const response = await axios(request);
+    console.log('register response: ', response.data);
+}

--- a/lambda/discord_interactions_endpoint/index.js
+++ b/lambda/discord_interactions_endpoint/index.js
@@ -16,40 +16,39 @@ exports.handler = async (event, context, callback) => {
   const server_instance_id = process.env.INSTANCE_ID;
   const ec2_instance_region = process.env.REGION;
 
-// By pass all discord authendication step for now
-//   const signature = event.headers['x-signature-ed25519'];
-//   const timestamp = event.headers['x-signature-timestamp'];
-     const strBody = event.body;
+  const signature = event.headers['x-signature-ed25519'];
+  const timestamp = event.headers['x-signature-timestamp'];
+  const strBody = event.body;
 
-//   const isVerified = nacl.sign.detached.verify(
-//     Buffer.from(timestamp + strBody),
-//     Buffer.from(signature, 'hex'),
-//     Buffer.from(PUBLIC_KEY, 'hex')
-//   );
-//   if (!isVerified) {
-//     return {
-//       statusCode: 401,
-//       body: JSON.stringify('invalid request signature'),
-//     };
-//   }
+  const isVerified = nacl.sign.detached.verify(
+    Buffer.from(timestamp + strBody),
+    Buffer.from(signature, 'hex'),
+    Buffer.from(PUBLIC_KEY, 'hex')
+  );
+  if (!isVerified) {
+    return {
+      statusCode: 401,
+      body: JSON.stringify('invalid request signature'),
+    };
+  }
 
-//   // Replying to ping (requirement 2.)
-     console.log('strB ',strBody)
-     const body = JSON.parse(strBody);
-     console.log(body)
-//   if (body.type == 1) {
-//     return {
-//       statusCode: 200,
-//       body: JSON.stringify({ "type": 1 }),
-//     }
-//   }
+  // Replying to ping (requirement 2.)
+    console.log('strB ',strBody)
+    const body = JSON.parse(strBody);
+    console.log(body)
+    if (body.type == 1) {
+      return {
+        statusCode: 200,
+        body: JSON.stringify({ "type": 1 }),
+      }
+    }
 
   //-------------Start processing discord commands-------------
   if(coldStart){
       coldStart = false;
       return JSON.stringify({ 
         "type": 4,
-        "data": { "content": "Cold Start...\n Try again please?" }
+        "data": { "content": "Just woke up...\n Can you try again?" }
       })
   }
   

--- a/lib/discord-interactions-endpoint-construct.ts
+++ b/lib/discord-interactions-endpoint-construct.ts
@@ -1,6 +1,6 @@
 import { Construct } from "constructs/lib/construct";
 import { STACK_PREFIX } from "./mine-cloud-stack";
-import {Function,Runtime,Code, FunctionUrlAuthType} from "aws-cdk-lib/aws-lambda"
+import {Function,Runtime,Code, FunctionUrlAuthType, FunctionUrl} from "aws-cdk-lib/aws-lambda"
 import path = require("path");
 import {PolicyStatement, Policy} from 'aws-cdk-lib/aws-iam';
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
@@ -14,6 +14,7 @@ import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
   export class DiscordInteractionsEndpointConstruct extends Construct {
 
     readonly lambdaFunction;
+    readonly lambdaFunctionURL: FunctionUrl;
 
     constructor(scope: Construct, id: string, props: DiscordInteractionsEndpointConstructProps) {
       super(scope, id);
@@ -40,7 +41,7 @@ import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
         }),
       );
 
-      this.lambdaFunction.addFunctionUrl(
+      this.lambdaFunctionURL = this.lambdaFunction.addFunctionUrl(
         {
           authType: FunctionUrlAuthType.NONE
         }

--- a/lib/mine-cloud-stack.ts
+++ b/lib/mine-cloud-stack.ts
@@ -1,6 +1,6 @@
 import { Construct } from "constructs";
 import { SpotInstance } from "./spot-instance";
-import { Duration, Stack, StackProps } from "aws-cdk-lib";
+import { CfnOutput, CustomResource, Duration, Stack, StackProps } from "aws-cdk-lib";
 import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import {
   AmazonLinuxGeneration,
@@ -28,7 +28,14 @@ import {
   Vpc,
 } from "aws-cdk-lib/aws-ec2";
 import { DiscordInteractionsEndpointConstruct } from './discord-interactions-endpoint-construct';
+import * as cr from 'aws-cdk-lib/custom-resources'
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Runtime } from "aws-cdk-lib/aws-lambda";
+import path = require("path");
 
+const DISCORD_PUBLIC_KEY = "";
+const DISCORD_APP_ID = "";
+const DISCORD_BOT_TOKEN = "";
 
 export const STACK_PREFIX = 'MineCloud';
 
@@ -37,7 +44,6 @@ const EC2_INSTANCE_TYPE = InstanceType.of(
   InstanceClass.T2,
   InstanceSize.LARGE
 );
-const DISCORD_PUBLIC_KEY = "";
 
 const MINECRAFT_USER = "minecraft";
 // Not the same name since cfn-init can't figure it out for some reason
@@ -45,14 +51,22 @@ const MINECRAFT_GROUP = "minecraft-group";
 const MINECRAFT_BASE_DIR = "/opt/minecraft";
 const MINECRAFT_SERVER_DIR = `${MINECRAFT_BASE_DIR}/server`;
 
+
+
 export class MineCloud extends Stack {
 
   readonly ec2Instance;
-  readonly  discordInteractionsEndpointLambda;
+  
+  readonly discordInteractionsEndpointLambda;
+  readonly discordInteractionsEndpointURL: CfnOutput;
+  
+  readonly discordCommandRegisterResource: CustomResource;
 
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
     this.ec2Instance = this.setupEC2Instance();
+    this.discordCommandRegisterResource = this.setupDiscordCommands();
+
     this.discordInteractionsEndpointLambda = new DiscordInteractionsEndpointConstruct(
       this,  
       `${STACK_PREFIX}_discord_interactions_endpoint_construct`,
@@ -63,6 +77,8 @@ export class MineCloud extends Stack {
       }
     );
     this.discordInteractionsEndpointLambda.node.addDependency(this.ec2Instance);
+    this.discordInteractionsEndpointURL = new CfnOutput(this, 'DISCORD-INTERACTIONS-ENDPOINT-URL', { 
+      value: this.discordInteractionsEndpointLambda.lambdaFunctionURL.url });
   }
 
   setupEC2Instance(): SpotInstance {
@@ -198,5 +214,34 @@ export class MineCloud extends Stack {
         ]),
       },
     });
+  }
+
+
+  setupDiscordCommands(): CustomResource{
+    const role = new Role(
+      this,
+      `${STACK_PREFIX}_discord_command_register_lambda_role`,
+      { assumedBy: new ServicePrincipal('lambda.amazonaws.com') }
+    );
+
+    const lambda = new NodejsFunction(this, `${STACK_PREFIX}_discord_commands_register_lambda`, {
+      runtime: Runtime.NODEJS_14_X, // We will want to upgrade this later
+      handler: 'index.handler',
+      entry: path.join(__dirname, '/../lambda/discord_commands_register/index.ts'),
+      environment:{
+        APP_ID: DISCORD_APP_ID,
+        BOT_TOKEN: DISCORD_BOT_TOKEN
+      }
+    });
+
+    const provider = new cr.Provider(this, `${STACK_PREFIX}_discord_commands_register_provider`, {
+      onEventHandler: lambda,   
+      role: role, 
+    });
+
+    const customResource = new CustomResource(this, `${STACK_PREFIX}_discord_commands_register_resource`, {
+      serviceToken: provider.serviceToken,
+    });
+    return customResource;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "2.72.1",
+        "aws-lambda": "^1.0.7",
         "aws-sdk": "^2.1351.0",
+        "axios": "^1.3.5",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21",
         "tweetnacl": "^1.0.3"
@@ -18,6 +20,7 @@
         "mine-cloud": "dist/bin/mine-cloud.js"
       },
       "devDependencies": {
+        "@types/aws-lambda": "^8.10.114",
         "@types/jest": "^29.4.0",
         "@types/node": "18.14.6",
         "aws-cdk": "2.72.1",
@@ -26,6 +29,9 @@
         "ts-jest": "^29.0.5",
         "ts-node": "^10.9.1",
         "typescript": "~4.9.5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1401,6 +1407,12 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.114",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.114.tgz",
+      "integrity": "sha512-M8WpEGfC9iQ6V2Ccq6nGIXoQgeVc6z0Ngk8yCOL5V/TYIxshvb0MWQYLFFTZDesL0zmsoBc4OBjG9DB/4rei6w==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
@@ -1601,10 +1613,14 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -1981,6 +1997,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/aws-lambda": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/aws-lambda/-/aws-lambda-1.0.7.tgz",
+      "integrity": "sha512-9GNFMRrEMG5y3Jvv+V4azWvc+qNWdWLTjDdhf/zgMlz8haaaLWv0xeAIWxz9PuWUBawsVxy0zZotjCdR3Xq+2w==",
+      "dependencies": {
+        "aws-sdk": "^2.814.0",
+        "commander": "^3.0.2",
+        "js-yaml": "^3.14.1",
+        "watchpack": "^2.0.0-beta.10"
+      },
+      "bin": {
+        "lambda": "bin/lambda"
+      }
+    },
     "node_modules/aws-sdk": {
       "version": "2.1351.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1351.0.tgz",
@@ -1999,6 +2029,16 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.5.tgz",
+      "integrity": "sha512-glL/PvG/E+xCWwV8S6nCHcrfg1exGx7vxyUIivIA1iL7BIh6bePylCfVHwp6k13ao7SATxB6imau2kqY+I67kw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2347,6 +2387,22 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2417,6 +2473,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -2538,7 +2602,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -2643,12 +2706,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -2748,6 +2843,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -2771,8 +2871,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -3693,7 +3792,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3830,6 +3928,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -4102,6 +4219,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -4270,8 +4392,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -4665,6 +4786,18 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cdk": "cdk"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.114",
     "@types/jest": "^29.4.0",
     "@types/node": "18.14.6",
     "aws-cdk": "2.72.1",
@@ -25,7 +26,9 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.72.1",
+    "aws-lambda": "^1.0.7",
     "aws-sdk": "^2.1351.0",
+    "axios": "^1.3.5",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21",
     "tweetnacl": "^1.0.3"


### PR DESCRIPTION
- When the stack deployed, invoked Discord APIs to register commands for the Bot
- Export `Discord Interactions Endpoint URL` as CloudFormation output  