### PR TITLE
Confiture Minecraft as a Systemd service and send events to Discord channel via webhook

### DIFF
--- a/MineCloud-Configs.ts
+++ b/MineCloud-Configs.ts
@@ -1,0 +1,6 @@
+export const DISCORD_PUBLIC_KEY = "";
+export const DISCORD_APP_ID = "";
+export const DISCORD_BOT_TOKEN = "";
+export const DISCORD_CHANNEL_WEB_HOOK = "";
+
+// More to add

--- a/server_init_assets/minecraft.service
+++ b/server_init_assets/minecraft.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Minecraft Server
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+WorkingDirectory=/opt/minecraft
+EnvironmentFile=/etc/environment
+
+Restart=always
+
+
+ExecStart=/usr/bin/screen -DmS mc_server ./start_service.sh
+
+ExecStop=/usr/bin/screen -S mc_server -X stuff 'say Server shutting down (closing by the system service)^M'
+ExecStop=/usr/bin/screen -S mc_server -X stuff 'save-all^M'
+ExecStop=/bin/sleep 10
+ExecStop=/usr/bin/screen -S mc_server -X stuff 'stop^M'
+ExecStop=/opt/minecraft/send_discord_message_to_webhook.sh "Shutting down the server >w<~"
+ExecStop=/bin/sleep 10
+ExecStop=/opt/minecraft/send_discord_message_to_webhook.sh "Server shut down"

--- a/server_init_assets/start_service.sh
+++ b/server_init_assets/start_service.sh
@@ -1,0 +1,10 @@
+cd /opt/minecraft
+echo "Server started: $(date)"
+public_ip=$(dig +short myip.opendns.com @resolver1.opendns.com)
+echo "new ip: $public_ip"
+./send_discord_message_to_webhook.sh "The server just spinned up!! Here's the IP 0w0 :\n$public_ip"
+echo discord message sent
+
+#start the Minecraft server
+cd server
+/usr/bin/env java -Xmx6144M -Xms1024M -jar server.jar nogui


### PR DESCRIPTION
- Confiture Minecraft as a Systemd service
- Send events to Discord channel via webhook. Events including: 
  - Server start event (IP address)
  - Minecraft system service stop event (crash/ec2 shutdown..etc)
    - When the Minecraft service shutting down, it will also save the world, make in-game broadcast, and gracefully close the server.     
- Run Minecraft server as a Screen session.