### PR TITLE
Create get_connection_count_udp_template.sh

### DIFF
--- a/minecloud_configs/advanced_configs/get_connection_count_udp_template.sh
+++ b/minecloud_configs/advanced_configs/get_connection_count_udp_template.sh
@@ -1,0 +1,10 @@
+function get_current_connection_count()
+{
+    local mcCons=$(sudo timeout 300 tcpdump -c 1 udp port 25565 2>/dev/null)
+
+    if [[ -z $mcCons ]]; then
+        echo 0
+    else
+        echo 1
+    fi
+}


### PR DESCRIPTION
This command runs `tcpdump`, a network traffic analyzer, with a timeout of 300 seconds (-c 1 means to capture only one packet) and filters for UDP traffic on port 25565. The stderr output of `tcpdump` is redirected to `/dev/null`.

The `if` statement checks whether the `mcCons` variable is empty using the `-z` operator. If it is empty, it means that there are no current connections to the server, so the function returns 0.

If the `mcCons` variable is not empty, it means that there is at least one current connection to the server, so the function returns 1.
